### PR TITLE
Implement a feature to allow users to delete multiple items at once.

### DIFF
--- a/kigen-majika-pyserver/domain/models/items/repository.py
+++ b/kigen-majika-pyserver/domain/models/items/repository.py
@@ -24,6 +24,10 @@ class IItemRepository(metaclass=ABCMeta):
     async def delete_by_id(self, id: int) -> None:
         pass
 
+    @abstractmethod
+    async def delete_by_ids(self, ids: list[int]) -> None:
+        pass
+
 
 class IJanCodeInfoRepository(metaclass=ABCMeta):
     @abstractmethod

--- a/kigen-majika-pyserver/externalfacade/items/repository.py
+++ b/kigen-majika-pyserver/externalfacade/items/repository.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, delete
 
 from domain.models import (
     Item,
@@ -171,6 +171,16 @@ class ItemRepository(IItemRepository):
         ret_obj = ret_objs[0]
         await db.delete(ret_obj[ItemMemo.__name__])
         await db.delete(ret_obj[ItemInventory.__name__])
+        await db.commit()
+
+    async def delete_by_ids(self, ids: list[int]) -> None:
+        db = self.session
+        if not ids:
+            return
+        stmt_memo = delete(ItemMemo).where(ItemMemo.id.in_(ids))
+        await db.execute(stmt_memo)
+        stmt_inventory = delete(ItemInventory).where(ItemInventory.id.in_(ids))
+        await db.execute(stmt_inventory)
         await db.commit()
 
 

--- a/kigen-majika-pyserver/inmemory/items/repository.py
+++ b/kigen-majika-pyserver/inmemory/items/repository.py
@@ -32,8 +32,13 @@ class ItemDictRepository(IItemRepository):
     async def delete_by_id(self, id: int) -> None:
         if id not in self.database:
             return None
-        item = self.database.pop(id)
+        self.database.pop(id)
         return
+
+    async def delete_by_ids(self, ids: list[int]) -> None:
+        for id in ids:
+            if id in self.database:
+                self.database.pop(id)
 
 
 class JanCodeInfoDictRepository(IJanCodeInfoRepository):

--- a/kigen-majika-pyserver/router/api/api.py
+++ b/kigen-majika-pyserver/router/api/api.py
@@ -21,6 +21,7 @@ from .usecase import (
     ItemCreate,
     ItemUpdate,
     ItemDelete,
+    ItemBulkDelete,
     ItemListResult,
     JanCodeInfoResult,
     ItemCreateResult,
@@ -32,6 +33,7 @@ from .param import (
     ItemUpdateParam,
     ItemCreateParam,
     ItemDeleteParam,
+    ItemListDelete,
     ItemRequestParam,
 )
 
@@ -117,3 +119,15 @@ async def read_api_item_delete(
         itemdeleteparam=itemdeleteparam
     )
     return itemdeleteresult
+
+
+@router.post("/items/bulk_delete", response_model=ItemDeleteResult)
+async def delete_api_items_bulk(
+    request: Request,
+    itemlistdelete: ItemListDelete,
+    db: AsyncSession = Depends(get_async_session),
+):
+    result = await ItemBulkDelete(itemrepository=ItemRepository(db)).delete(
+        itemlistdelete=itemlistdelete
+    )
+    return result

--- a/kigen-majika-pyserver/router/api/param/items.py
+++ b/kigen-majika-pyserver/router/api/param/items.py
@@ -53,3 +53,7 @@ class ItemUpdateParam(BaseModel):
 
 class ItemDeleteParam(BaseModel):
     id: int
+
+
+class ItemListDelete(BaseModel):
+    ids: list[int]

--- a/kigen-majika-pyserver/router/api/usecase/itemdelete.py
+++ b/kigen-majika-pyserver/router/api/usecase/itemdelete.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 
 from domain.models import IItemRepository
-from router.api.param import ItemDeleteParam
+from router.api.param import ItemDeleteParam, ItemListDelete
 
 
 class ItemDeleteResult(BaseModel):
@@ -16,4 +16,15 @@ class ItemDelete:
 
     async def delete(self, itemdeleteparam: ItemDeleteParam) -> ItemDeleteResult:
         await self.itemrepository.delete_by_id(id=itemdeleteparam.id)
+        return ItemDeleteResult()
+
+
+class ItemBulkDelete:
+    itemrepository: IItemRepository
+
+    def __init__(self, itemrepository: IItemRepository):
+        self.itemrepository = itemrepository
+
+    async def delete(self, itemlistdelete: ItemListDelete) -> ItemDeleteResult:
+        await self.itemrepository.delete_by_ids(ids=itemlistdelete.ids)
         return ItemDeleteResult()

--- a/kigen-majika-pyserver/router/html/items.py
+++ b/kigen-majika-pyserver/router/html/items.py
@@ -12,6 +12,7 @@ from .param import (
     EditItemGetForm,
     EditItemPostForm,
     DeleteItemPostForm,
+    DeleteItemBulkPostForm,
 )
 from .usecase import (
     AddItemFormResult,
@@ -22,6 +23,7 @@ from .usecase import (
     EditItemForm,
     DeleteItemInitForm,
     DeleteItemForm,
+    DeleteItemBulkForm,
 )
 from application.items.connect_api import ConnectToAPIJanCodeInfoCreator
 from .usecase.shared import util as s_util
@@ -53,6 +55,37 @@ async def read_users_items(
         request=request, name="users/itemlist.html", context=result.get_context()
     )
     return ret
+
+
+@router.get("/delete_bulk", response_class=HTMLResponse)
+async def read_users_items_delete_bulk(
+    request: Request, itemlistgetform: ItemListGetForm = Depends()
+):
+    result = await ItemListInHTML(
+        api_url=str(request.url_for("read_api_items")),
+        local_timezone=s_util.JST,
+        itemlistgetform=itemlistgetform,
+    ).execute()
+    ret = templates.TemplateResponse(
+        request=request,
+        name="users/delete_items_bulk.html",
+        context=result.get_context(),
+    )
+    return ret
+
+
+@router.post("/delete_bulk/result", response_class=HTMLResponse)
+async def read_users_items_delete_bulk_result(
+    request: Request, deleteitembulkpostform: DeleteItemBulkPostForm = Depends()
+):
+    await DeleteItemBulkForm(
+        deleteitembulkpostform=deleteitembulkpostform,
+        delete_api_url=str(request.url_for("delete_api_items_bulk")),
+    ).execute()
+    return RedirectResponse(
+        url=request.url_for("read_users_items_delete_bulk"),
+        status_code=status.HTTP_303_SEE_OTHER,
+    )
 
 
 @router.get("/readjancode", response_class=HTMLResponse)

--- a/kigen-majika-pyserver/router/html/param/items.py
+++ b/kigen-majika-pyserver/router/html/param/items.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone, timedelta
+from typing import List
 
 from fastapi import Form
 
@@ -163,3 +164,10 @@ class DeleteItemPostForm(BaseModel):
             super().__init__(id=int(id), name=name)
         else:
             ValueError("id is not int")
+
+
+class DeleteItemBulkPostForm(BaseModel):
+    delete_item_ids: List[int]
+
+    def __init__(self, delete_item_ids: List[int] = Form(...)):
+        super().__init__(delete_item_ids=delete_item_ids)

--- a/kigen-majika-pyserver/router/html/usecase/deleteitemform.py
+++ b/kigen-majika-pyserver/router/html/usecase/deleteitemform.py
@@ -9,7 +9,7 @@ from .shared.readitemform import (
     GetOneItemCommand,
 )
 from router.api.usecase import ItemDeleteResult
-from router.html.param import DeleteItemPostForm
+from router.html.param import DeleteItemPostForm, DeleteItemBulkPostForm
 
 
 class DeleteItemFormResult(htmlcontext.HtmlContext):
@@ -70,6 +70,28 @@ class DeleteItemInitForm:
             input_date=result.updated_at, tz=self.local_timezone
         )
         return result
+
+
+class DeleteItemBulkForm:
+    deleteitembulkpostform: DeleteItemBulkPostForm
+    delete_api_url: str
+
+    def __init__(
+        self,
+        deleteitembulkpostform: DeleteItemBulkPostForm,
+        delete_api_url: str,
+    ):
+        self.deleteitembulkpostform = deleteitembulkpostform
+        self.delete_api_url = delete_api_url
+
+    async def execute(self) -> None:
+        async with httpx.AsyncClient() as client:
+            request_body = {"ids": self.deleteitembulkpostform.delete_item_ids}
+            res = await client.post(
+                self.delete_api_url,
+                json=request_body,
+            )
+            res.raise_for_status()
 
 
 class DeleteItemForm:

--- a/kigen-majika-pyserver/templates/users/delete_items_bulk.html
+++ b/kigen-majika-pyserver/templates/users/delete_items_bulk.html
@@ -1,0 +1,123 @@
+{% extends "shared/base.html" %}
+
+{% block head %}
+    <link rel="stylesheet" href="{{ url_for('static', path='/css/style.css') }}" type="text/css">
+    <title>アイテム一括削除</title>
+    <script>
+        function confirmDelete() {
+            const checkboxes = document.querySelectorAll('input[name="delete_item_ids"]:checked');
+            if (checkboxes.length === 0) {
+                alert('削除するアイテムを選択してください。');
+                return false;
+            }
+            return confirm('選択したアイテムを本当に削除しますか？');
+        }
+        function scrollToTop() {
+            window.scrollTo(0, 0);
+        }
+        function scrollToBottom() {
+            window.scrollTo(0, document.body.scrollHeight);
+        }
+    </script>
+{% endblock %}
+
+{% block body %}
+    <a id="top"></a>
+    <h1>アイテム一括削除</h1>
+    <h2>操作メニュー</h2>
+    <p><a href="{{ url_for('read_users_items') }}" class="like_button_link">アイテム一覧に戻る</a></p>
+    <h3>フィルタ</h3>
+    <p>
+        {%- with
+            FORM_METHOD = inventory_filter.form.method,
+            FORM_ACTION = inventory_filter.form.action,
+            MENU_TITLE = inventory_filter.select.title,
+            MENU_NAME = inventory_filter.select.input_name,
+            menu_list = inventory_filter.select.menu_list,
+            hidden_input_dict = hidden_input_dict
+        %}
+        {%- include "shared/pulldown_menu_filter.html" %}
+        {%- endwith %}
+    </p>
+    <p>
+        {%- with
+            FORM_METHOD = sort_order.form.method,
+            FORM_ACTION = sort_order.form.action,
+            MENU_TITLE = sort_order.select.title,
+            MENU_NAME = sort_order.select.input_name,
+            menu_list = sort_order.select.menu_list,
+            hidden_input_dict = hidden_input_dict
+        %}
+        {%- include "shared/pulldown_menu_sort.html" %}
+        {%- endwith %}
+    </p>
+    <p>
+        {%- with
+            FORM_METHOD = search_filter.form.method,
+            FORM_ACTION = search_filter.form.action,
+            MENU_TITLE = search_filter.select.title,
+            MENU_NAME = search_filter.select.input_name,
+            menu_list = search_filter.select.menu_list,
+            INPUT_TEXT_NAME = search_filter.inputtext.name,
+            INPUT_TEXT_VALUE = search_filter.inputtext.value,
+            hidden_input_dict = hidden_input_dict
+        %}
+        {%- include "shared/keyword_search_filter.html" %}
+        {%- endwith %}
+    </p>
+    <p><a href="{{ url_for('read_users_items_delete_bulk') }}" class="plain-link">フィルタクリア</a></p>
+    <p><button type="button" onclick="scrollToBottom()" class="like_button">一番下へ</button></p>
+    <p>
+        件数
+        {{ items_length }}件
+    </p>
+    <form action="{{ url_for('read_users_items_delete_bulk_result') }}" method="post" onsubmit="return confirmDelete();">
+        <table class="item_list_table">
+            <tr>
+                <th>削除</th>
+                <th>id</th>
+                <th>商品名</th>
+                <th>JANコード</th>
+                <th>在庫数</th>
+                <th>カテゴリー</th>
+                <th>メーカー</th>
+                <th>保管場所</th>
+                <th>消費期限</th>
+                <th>注意度</th>
+                <th>備考</th>
+                <th>更新日</th>
+                <th>登録日</th>
+            </tr>
+            {%- for row in items %}
+            <tr>
+                <td><input type="checkbox" name="delete_item_ids" value="{{ row['id'] }}"></td>
+                <td>{{ row["id"] }}</td>
+                <td>{{row["name"]}}</td>
+                <td>{{row["jan_code"]["value"]}}</td>
+                <td>{{row["inventory"]}}</td>
+                <td>{{row["category"]}}</td>
+                <td>{{row["manufacturer"]}}</td>
+                <td>{{row["place"]}}</td>
+                <td>{{row["expiry_date"] | toLocalExpiryDateTextFormat }}</td>
+                <td>
+                    {%- if row["days_to_deadline"] | is_expired %}
+                    <span class="purple_text">危険</span>
+                    {%- elif row["days_to_deadline"] | is_caution %}
+                    <span class="red_text">注意</span>
+                    {%- elif row["days_to_deadline"] | is_somewhat_caution %}
+                    <span class="sandybrown_text">やや注意</span>
+                    {%- else %}
+                    <span>ー</span>
+                    {%- endif %}
+                </td>
+                <td>{{row["text"]}}</td>
+                <td>{{row["updated_at"] | toLocalTextFormat }}</td>
+                <td>{{row["created_at"] | toLocalTextFormat }}</td>
+            </tr>
+            {%- endfor %}
+        </table>
+        <p><button type="submit" class="like_button_link">はまとめて削除</button></p>
+    </form>
+    <p><button type="button" onclick="scrollToTop()" class="like_button">一番上へ</button></p>
+    <a id="bottom"></a>
+{% endblock %}

--- a/kigen-majika-pyserver/templates/users/itemlist.html
+++ b/kigen-majika-pyserver/templates/users/itemlist.html
@@ -9,6 +9,7 @@
     <h1>アイテム一覧</h1>
     <h2>操作メニュー</h2>
     <p><a href="{{ url_for('read_users_items_add_jancode') }}" class="like_button_link">アイテムを追加</a></p>
+    <p><a href="{{ url_for('read_users_items_delete_bulk') }}" class="like_button_link">アイテムを削除</a></p>
     <h3>フィルタ</h3>
     <p>
         {%- with


### PR DESCRIPTION
Key changes:
- Adds a "Delete Items" button on the main item list page, which navigates to a new bulk deletion page.
- Creates a new page (`/items/delete_bulk`) that displays a list of items with checkboxes.
- Users can select multiple items and delete them by clicking the "Delete Selected Items" button.
- Adds "Scroll to Top" and "Scroll to Bottom" buttons for convenience.
- Implements a new API endpoint `POST /api/items/bulk_delete` to handle the deletion logic.
- The repository layer has been updated with a `delete_by_ids` method for efficient bulk deletion from the database.

Work was completed up to the testing phase. I attempted to run the existing test suite to ensure no regressions were introduced. The tests failed with a `ModuleNotFoundError` for `sqlalchemy`, likely due to a Python environment issue. I installed all dependencies from `requirements.txt` but the error persisted when running `pytest`. The user suggested an alternative command `python -m pytest tests`, which I was unable to try. The feature is implemented, but requires testing to be fully verified.